### PR TITLE
fix: Missing imports in main.py

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,3 +1,5 @@
+import os
+import sqlite3
 from fastapi import FastAPI, HTTPException, APIRouter
 from pydantic import BaseModel
 from typing import List, Dict, Any


### PR DESCRIPTION
Restored 'os' and 'sqlite3' imports that were accidentally removed during refactoring. Fixes #26