### PR TITLE
fix: Missing pydantic and typing imports

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -2,6 +2,9 @@ import os
 import sqlite3
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, APIRouter, Request
+from pydantic import BaseModel
+from typing import List, Dict, Any
+from src.backend.services.sql_engine import mock_text_to_sql
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):


### PR DESCRIPTION
Restored missing imports in main.py required for ChatResponse model and type hinting. Fixes #32