### PR TITLE
fix: Align manual backend port with frontend proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ python3 data/etl_scripts/fetch_opendigger.py
 ### 2. 启动后端侦探服务 (Backend)
 ```bash
 # 确保还在虚拟环境中
-uvicorn src.backend.main:app --reload
-# 服务将运行在 http://localhost:8000
+uvicorn src.backend.main:app --reload --port 8081
+# 服务将运行在 http://localhost:8081
 ```
 
 ### 3. 启动前端指挥中心 (Frontend)

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Start Open-Detective Backend on the correct port (8081)
+source .venv/bin/activate
+uvicorn src.backend.main:app --reload --port 8081


### PR DESCRIPTION
Updated the documentation and added a helper script to ensure the backend starts on port 8081, matching the frontend proxy configuration. Fixes #75