### PR TITLE
fix: Backend dependencies and startup command

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -13,4 +13,4 @@ COPY data ./data
 RUN python data/etl_scripts/mock_data.py
 
 EXPOSE 8081
-CMD ["uvicorn", "src.backend.main:app", "--host", "0.0.0.0", "--port", "8081"]
+CMD ["python", "-m", "uvicorn", "src.backend.main:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -1,3 +1,5 @@
+fastapi
+uvicorn
+pydantic
 python-dotenv
 requests
-fastapi


### PR DESCRIPTION
Restored missing uvicorn/pydantic in requirements.txt and switched to 'python -m uvicorn' for reliable startup.