### PR TITLE
fix: Passthrough SQLBOT_API_KEY to backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - SQL_ENGINE_TYPE=sqlbot
       - SQLBOT_ENDPOINT=http://sqlbot:8000
       - DATABASE_PATH=/app/db_shared/open_detective.db
+      - SQLBOT_API_KEY=${SQLBOT_API_KEY}
     depends_on:
       - sqlbot
 


### PR DESCRIPTION
Ensured that the SQLBOT_API_KEY is correctly passed from the host environment to the backend container in docker-compose. Fixes #89