### PR TITLE
fix: Correct SQLBot auth header

### DIFF
--- a/src/backend/services/sqlbot_client.py
+++ b/src/backend/services/sqlbot_client.py
@@ -39,7 +39,7 @@ class SQLBotClient:
 
         url = f"{self.endpoint}/api/v1/chat"
         headers = {
-            "Authorization": f"Bearer {self.api_key}",
+            "X-SQLBOT-TOKEN": self.api_key,
             "Content-Type": "application/json"
         }
         payload = {


### PR DESCRIPTION
Changed 'Authorization' header to 'X-SQLBOT-TOKEN' to match DataEase SQLBot API requirements. Fixes #91