### PR TITLE
fix: Use Static Session Token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
 # AI Engine Configuration
-SQL_ENGINE_TYPE=mock
+SQL_ENGINE_TYPE=sqlbot
 SQLBOT_ENDPOINT=http://localhost:8080
-SQLBOT_ACCESS_KEY=admin
-# Must match the SECRET_KEY in SQLBot container (default: y5txe1mRmS_JpOrUzFzHEu-kIQn3lf7ll0AOv9DQh0s)
-SQLBOT_SECRET_KEY=y5txe1mRmS_JpOrUzFzHEu-kIQn3lf7ll0AOv9DQh0s
+# Capture this from browser network tab (X-SQLBOT-TOKEN)
+SQLBOT_API_KEY="Bearer eyJhbGci..."
 SQLBOT_DATASOURCE_ID=1
 
 # MySQL Database Configuration


### PR DESCRIPTION
Replaced complex AK/SK logic with simple static token pass-through to support browser-captured session tokens. Fixes #134