### PR TITLE
feat: support multi-repo comparison

### DIFF
--- a/tests/test_sql_gen.py
+++ b/tests/test_sql_gen.py
@@ -9,17 +9,20 @@ from src.backend.services.sql_engine import mock_text_to_sql
 
 def test_sql_gen_basic():
     sql = mock_text_to_sql("stars for vue")
-    assert "repo_name = 'vuejs/core'" in sql
+    assert "repo_name IN" in sql
+    assert "'vuejs/core'" in sql
     assert "metric_type = 'stars'" in sql
 
 def test_sql_gen_activity():
     sql = mock_text_to_sql("activity of react")
-    assert "repo_name = 'facebook/react'" in sql
+    assert "repo_name IN" in sql
+    assert "'facebook/react'" in sql
     assert "metric_type = 'activity'" in sql
 
 def test_sql_gen_bus_factor():
     sql = mock_text_to_sql("what is the bus factor of tensorflow")
-    assert "repo_name = 'tensorflow/tensorflow'" in sql
+    assert "repo_name IN" in sql
+    assert "'tensorflow/tensorflow'" in sql
     assert "metric_type = 'bus_factor'" in sql
 
 def test_sql_gen_unknown_repo():
@@ -28,14 +31,16 @@ def test_sql_gen_unknown_repo():
 
 def test_sql_gen_vscode():
     sql = mock_text_to_sql("vscode issues")
-    assert "repo_name = 'microsoft/vscode'" in sql
+    assert "repo_name IN" in sql
+    assert "'microsoft/vscode'" in sql
     assert "metric_type = 'issues_new'" in sql
 
 def test_sql_gen_ollama():
     sql = mock_text_to_sql("stars for ollama")
-    assert "repo_name = 'ollama/ollama'" in sql
+    assert "repo_name IN" in sql
+    assert "'ollama/ollama'" in sql
 
 def test_sql_gen_rust():
     sql = mock_text_to_sql("activity of rust-lang/rust")
-    assert "repo_name = 'rust-lang/rust'" in sql
-
+    assert "repo_name IN" in sql
+    assert "'rust-lang/rust'" in sql

--- a/tests/test_sql_gen_multi.py
+++ b/tests/test_sql_gen_multi.py
@@ -1,0 +1,37 @@
+import sys
+import os
+import pytest
+
+# Add src to python path so we can import modules
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+
+from src.backend.services.sql_engine import mock_text_to_sql
+
+def test_sql_gen_compare_vue_react():
+    sql = mock_text_to_sql("compare vue and react stars")
+    assert "repo_name IN" in sql
+    assert "'vuejs/core'" in sql
+    assert "'facebook/react'" in sql
+    assert "metric_type = 'stars'" in sql
+    assert "SELECT month, value, repo_name" in sql
+
+def test_sql_gen_compare_three_repos():
+    sql = mock_text_to_sql("activity of vue, react and tensorflow")
+    assert "repo_name IN" in sql
+    assert "'vuejs/core'" in sql
+    assert "'facebook/react'" in sql
+    assert "'tensorflow/tensorflow'" in sql
+    assert "metric_type = 'activity'" in sql
+
+def test_sql_gen_vs_keyword():
+    sql = mock_text_to_sql("vue vs react")
+    assert "repo_name IN" in sql
+    assert "'vuejs/core'" in sql
+    assert "'facebook/react'" in sql
+
+def test_sql_gen_react_not_preact():
+    sql = mock_text_to_sql("stars for react")
+    assert "'facebook/react'" in sql
+    # 'preactjs/preact' should NOT be in the result if strict matching works
+    # "react" is not start of "preactjs" or "preact"
+    assert "'preactjs/preact'" not in sql


### PR DESCRIPTION
This PR updates the Mock Engine to support multi-repo comparison queries (e.g. 'Compare Vue and React'). It generates SQL with 'IN' clause and 'repo_name' in SELECT. The frontend 'ResultChart.vue' is updated to visualize multiple series.