### PR TITLE
fix: SQLBot connection and auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 # AI Engine Configuration
 SQL_ENGINE_TYPE=sqlbot
 SQLBOT_ENDPOINT=http://localhost:8080
+# Option 1: Direct Token (Recommended)
 # Capture this from browser network tab (X-SQLBOT-TOKEN)
 SQLBOT_API_KEY="Bearer eyJhbGci..."
+
+# Option 2: Automatic Login (Fallback)
+SQLBOT_USERNAME=admin
+SQLBOT_PASSWORD=SQLBot@123456
+
 SQLBOT_DATASOURCE_ID=1
 
 # MySQL Database Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - SQL_ENGINE_TYPE=sqlbot
       - SQLBOT_ENDPOINT=http://sqlbot:8000
       - DATABASE_PATH=/app/db_shared/open_detective.db
+      - SQLBOT_API_KEY=${SQLBOT_API_KEY}
+      - SQLBOT_USERNAME=${SQLBOT_USERNAME}
+      - SQLBOT_PASSWORD=${SQLBOT_PASSWORD}
       - SQLBOT_ACCESS_KEY=${SQLBOT_ACCESS_KEY}
       - SQLBOT_SECRET_KEY=${SQLBOT_SECRET_KEY}
     depends_on:


### PR DESCRIPTION
Enables SQLBOT_API_KEY support in backend client and properly passes env vars in docker-compose.