### PR TITLE
Optimization: Use httpx for asynchronous health checks

### DIFF
--- a/src/backend/api/v1/endpoints/health.py
+++ b/src/backend/api/v1/endpoints/health.py
@@ -1,42 +1,44 @@
-from fastapi import APIRouter, Request
-from src.backend.schemas.chat import HealthResponse
 import os
-import requests
+
+import httpx
+from fastapi import APIRouter, Request
+
+from src.backend.schemas.chat import HealthResponse
 
 router = APIRouter()
 
 from datetime import datetime, timezone
+
 
 @router.get("/health", response_model=HealthResponse)
 async def health_check(request: Request):
     db_status = False
     pool_info = {}
     try:
-        if hasattr(request.app.state, 'pool'):
+        if hasattr(request.app.state, "pool"):
             pool = request.app.state.pool
             async with pool.acquire() as conn:
                 await conn.ping()
                 db_status = True
-            pool_info = {
-                "size": pool.size,
-                "free": pool.freesize
-            }
+            pool_info = {"size": pool.size, "free": pool.freesize}
     except Exception as e:
         pool_info["error"] = str(e)
-    
+
     return {
-        "status": "ok", 
-        "version": "1.0.0", 
+        "status": "ok",
+        "version": "1.0.0",
         "db_connected": db_status,
         "details": pool_info,
-        "timestamp": datetime.now(timezone.utc).isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
+
 
 @router.get("/sqlbot-health")
 async def sqlbot_health():
     endpoint = os.getenv("SQLBOT_ENDPOINT", "http://sqlbot:8000")
     try:
-        res = requests.get(endpoint, timeout=2)
-        return {"status": "reachable", "code": res.status_code}
+        async with httpx.AsyncClient() as client:
+            res = await client.get(endpoint, timeout=2.0)
+            return {"status": "reachable", "code": res.status_code}
     except Exception as e:
         return {"status": "unreachable", "error": str(e)}


### PR DESCRIPTION
Replaced synchronous 'requests' with asynchronous 'httpx' in 'src/backend/api/v1/endpoints/health.py' to improve performance and avoid blocking the event loop. Fixes #378.