### PR TITLE
Optimization 5: Add type hints to sqlbot_text_to_sql

### DIFF
--- a/src/backend/services/sqlbot_client.py
+++ b/src/backend/services/sqlbot_client.py
@@ -431,5 +431,5 @@ Question: {question}
         return result
 
 
-def sqlbot_text_to_sql(text: str) -> str:
+def sqlbot_text_to_sql(text: str) -> str | None:
     return SQLBotClient().generate_sql(text)


### PR DESCRIPTION
Added optional return type hint to 'sqlbot_text_to_sql' to match its implementation. Fixes #388.