### PR TITLE
Refactor: Use sys.exit for cleaner startup failure

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -104,8 +104,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     if not pool:
         logger.critical("Could not connect to MySQL after multiple attempts. Exiting.")
-        err_msg = "Database connection failed"
-        raise RuntimeError(err_msg)
+        sys.exit(1)
 
     duration = time.time() - start_time
     logger.info(f"Startup complete in {duration:.2f}s")


### PR DESCRIPTION
Changed startup error handling to use sys.exit(1) for consistent exit codes. Fixes #436.