### PR TITLE
Enhance: Exclude .DS_Store in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .git
 .gitignore
 .env
+.DS_Store
 .pytest_cache/
 .ruff_cache/
 .venv/


### PR DESCRIPTION
Excluded common macOS metadata files from the docker context. Fixes #484.