### PR TITLE
Improve: Add response_model to ping endpoint

### DIFF
--- a/src/backend/api/v1/endpoints/health.py
+++ b/src/backend/api/v1/endpoints/health.py
@@ -41,7 +41,7 @@ async def health_check(request: Request):
     }
 
 
-@router.get("/ping", tags=["System"])
+@router.get("/ping", tags=["System"], response_model=str)
 async def ping():
     """Minimal connectivity check."""
     return "pong"


### PR DESCRIPTION
Defined explicit response model for the ping endpoint. Fixes #488.