### PR TITLE
Improve: Ensure frontend dist directory is cleared before build

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "build": "vue-tsc && vite build",
+    "build": "vue-tsc && vite build --emptyOutDir",
     "preview": "vite preview"
   },
 


### PR DESCRIPTION
Added --emptyOutDir to Vite build command for safer deployments. Fixes #566.