### PR TITLE
Refactor: Use NamedTuple for REPO_MOCK_DATA in analytics

### DIFF
--- a/src/backend/api/v1/endpoints/analytics.py
+++ b/src/backend/api/v1/endpoints/analytics.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, NamedTuple
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field, field_validator
@@ -8,9 +8,19 @@ from src.backend.services.analytics import detect_anomalies
 
 router = APIRouter()
 
+
+class RepoMetrics(NamedTuple):
+    name: str
+    v1: float
+    v2: float
+    v3: float
+    v4: float
+    v5: float
+
+
 REPO_MOCK_DATA = {
-    "vue": ("Vue.js", 95, 80, 90, 70, 85),
-    "react": ("React", 98, 90, 95, 80, 90),
+    "vue": RepoMetrics("Vue.js", 95, 80, 90, 70, 85),
+    "react": RepoMetrics("React", 98, 90, 95, 80, 90),
 }
 
 


### PR DESCRIPTION
Improved readability by replacing raw tuples with a NamedTuple structure. Fixes #589.